### PR TITLE
Fix client_authentication

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -149,7 +149,7 @@ resource "aws_msk_cluster" "default" {
     for_each = var.client_tls_auth_enabled || var.client_sasl_scram_enabled || var.client_sasl_iam_enabled ? [1] : []
     content {
       dynamic "tls" {
-        for_each = var.client_tls_auth_enabled ? [1] : []
+        for_each = var.client_tls_auth_enabled || var.client_sasl_scram_enabled ? [1] : []
         content {
           certificate_authority_arns = var.certificate_authority_arns
         }


### PR DESCRIPTION

According to AWS managed Kafka document:

`Clients that use IAM, SASL/SCRAM, or TLS authentication must also use TLS encryption to communicate with the brokers.`

To enable SASL/SCRAM, TLS authentication is needed.
